### PR TITLE
Add base CircleCI configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ all: activities
 activities:
 	@docker build -f ./Dockerfile -t $(DOCKER_IMAGE) .
 
-
 start: activities
 	@docker run \
 		--name oam-server-activities \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # OpenAerialMap Server: Activities component
 
+[![Circle CI](https://circleci.com/gh/hotosm/oam-server-activities/tree/master.svg?style=svg)](https://circleci.com/gh/hotosm/oam-server-activities/tree/master)
+[![Docker Repository on Quay.io](https://quay.io/repository/hotosm/oam-server-activities/status "Docker Repository on Quay.io")](https://quay.io/repository/hotosm/oam-server-activities)
+
 The Activities component of OAM Server is a [swfr](http://github.com/stamen/swfr) SWF activities worker that processes OAM tiling tasks.
 
 ## Activities

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,23 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+    - docker login -e . -p ${QUAY_PASSWORD} -u ${QUAY_USER} quay.io
+
+test:
+  pre:
+    - docker build -t quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1:0:7} .
+  override:
+    - /bin/true
+
+deployment:
+  latest:
+    branch: master
+    commands:
+      - docker push quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1:0:7}
+  release:
+    tag: /[0-9]+(\.[0-9]+)*/
+    commands:
+      - docker push quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:$(git tag -l --contains HEAD)


### PR DESCRIPTION
Currently, CircleCI isn't actually running any tests (only `/bin/true`), but that can easily be updated in `circle.yml`.

More interesting is that CircleCI is setup to build and publish container images (to Quay) for all merges into `master` using the first seven characters of the Git commit as the container image's tag. Git tag pushes also produce container images, which are identified by the same version number of the tag.

See also:
- https://circleci.com/gh/hotosm/oam-server-activities
- https://quay.io/repository/hotosm/oam-server-activities

Related to https://github.com/hotosm/oam-server/issues/12
